### PR TITLE
Fix: Typo in "GNU" (was written as "GUN")

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ if you're interested in contributing code, feel free to check out our GitHub
 ## 📝 License
 
 Copyright © 2024 [PPanel][profile-link]. <br />
-This project is [GUN](../../LICENSE) licensed.
+This project is [GNU](../../LICENSE) licensed.
 
 <!-- LINK GROUP -->
 

--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -107,7 +107,7 @@ if you're interested in contributing code, feel free to check out our GitHub
 ## 📝 License
 
 Copyright © 2024 [PPanel][profile-link]. <br />
-This project is [GUN](../../LICENSE) licensed.
+This project is [GNU](../../LICENSE) licensed.
 
 <!-- LINK GROUP -->
 

--- a/apps/admin/README.zh-CN.md
+++ b/apps/admin/README.zh-CN.md
@@ -107,7 +107,7 @@ pnpm dev
 ## 📝 许可证
 
 版权所有 © 2024 [PPanel][profile-link]。<br />
-本项目使用 [GUN](./LICENSE) 许可证。
+本项目使用 [GNU](./LICENSE) 许可证。
 
 <!-- LINK GROUP -->
 

--- a/apps/user/README.md
+++ b/apps/user/README.md
@@ -107,7 +107,7 @@ if you're interested in contributing code, feel free to check out our GitHub
 ## 📝 License
 
 Copyright © 2024 [PPanel][profile-link]. <br />
-This project is [GUN](../../LICENSE) licensed.
+This project is [GNU](../../LICENSE) licensed.
 
 <!-- LINK GROUP -->
 

--- a/apps/user/README.zh-CN.md
+++ b/apps/user/README.zh-CN.md
@@ -107,7 +107,7 @@ pnpm dev
 ## 📝 许可证
 
 版权所有 © 2024 [PPanel][profile-link]。<br />
-本项目使用 [GUN](./LICENSE) 许可证。
+本项目使用 [GNU](./LICENSE) 许可证。
 
 <!-- LINK GROUP -->
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] 🐛 fix
- [ ] ✨ feat
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Corrected a typo in the documentation: "GNU" was misspelled as "GUN".

#### 📝 补充信息 | Additional Information

The typo occurred in the **introduction section** of `README.md` and `README.md.zh-CN.md`. No other changes were made.
