### PR TITLE
fix: 服务器编辑时合并协议默认配置

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
 <a name="readme-top"></a>
+# Changelog
+
+# [1.6.0](https://github.com/perfect-panel/ppanel-web/compare/v1.5.4...v1.6.0) (2025-10-28)
+
+
+### ✨ Features
+
+* Add server installation dialog and commands ([4429c9d](https://github.com/perfect-panel/ppanel-web/commit/4429c9d))
+
+
+### 🐛 Bug Fixes
+
+* Add typeRoots configuration to ensure type definitions are resolved correctly ([ad60ea9](https://github.com/perfect-panel/ppanel-web/commit/ad60ea9))
+
+<a name="readme-top"></a>
 
 # Changelog
 

--- a/apps/admin/app/dashboard/servers/server-form.tsx
+++ b/apps/admin/app/dashboard/servers/server-form.tsx
@@ -356,7 +356,8 @@ export default function ServerForm(props: {
         ...initialValues,
         protocols: PROTOCOLS.map((type) => {
           const existingProtocol = initialValues.protocols?.find((p) => p.type === type);
-          return existingProtocol || getProtocolDefaultConfig(type);
+          const defaultConfig = getProtocolDefaultConfig(type);
+          return existingProtocol ? { ...defaultConfig, ...existingProtocol } : defaultConfig;
         }),
       });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppanel-web",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "private": true,
   "homepage": "https://github.com/perfect-panel/ppanel-web",
   "bugs": {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

**修复服务器表单编辑时协议默认字段缺失的问题**

修复了编辑服务器时，如果后端返回的协议配置缺少默认值字段（如 `fingerprint`），导致提交数据不一致的问题。

**问题现象：**
- 编辑 VLESS 服务器时，如果 `fingerprint` 使用默认值 `chrome`，后端可能不返回该字段
- 表单初始化时 `fingerprint` 为 `undefined`，导致首次提交时该字段缺失
- 修改为其他指纹（如 `firefox`）后再改回 `chrome`，字段才会出现

**修复内容：**
- 在 `useEffect` 中合并协议默认配置与后端返回数据
- 使用 `{ ...defaultConfig, ...existingProtocol }` 确保所有默认值字段都存在
- 保证编辑和创建时的字段处理逻辑一致

**影响范围：**
- 影响所有协议的默认字段（`fingerprint`、`transport`、`security` 等）
- 提升数据完整性和一致性

#### 📝 补充信息 | Additional Information

**变更文件：**
- `apps/admin/app/dashboard/servers/server-form.tsx`

**相关协议：**
影响所有支持 `fingerprint` 的协议：vmess、vless、trojan、hysteria、tuic、anytls、naive、http