### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,10 +235,10 @@ Trace:
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=perfect-panel%2Fppanel-backend&type=timeline&legend=top-left">
+<a href="https://star-history.dera.page/#perfect-panel/ppanel-backend&type=timeline&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=perfect-panel/ppanel-backend&type=timeline&theme=dark&logscale&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=perfect-panel/ppanel-backend&type=timeline&logscale&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=perfect-panel/ppanel-backend&type=timeline&logscale&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=perfect-panel/ppanel-backend&type=timeline&theme=dark&logscale&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=perfect-panel/ppanel-backend&type=timeline&logscale&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=perfect-panel/ppanel-backend&type=timeline&logscale&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is currently broken because it relies on the GitHub stargazer API, which now restricts access and prevents the chart from rendering. This change updates the chart to use a working source so visitors can see the project's star history again.

The wrapping link and the embedded chart image have both been updated accordingly.